### PR TITLE
Add basic streamlit dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,43 @@
+import dask_deltatable as ddt
+import streamlit as st
+
+from preprocess import OUTDIR
+
+
+def get_data(variable):
+    df = ddt.read_deltalake(OUTDIR / "dask" / variable).compute()
+    df = df.drop(columns="__index_level_0__")
+    df["repo"] = "https://github.com/" + df["repo"]
+    df["username"] = "https://github.com/" + df["username"]
+    # Streamlit doesn't like pyarrow strings
+    # (xref https://github.com/streamlit/streamlit/issues/6334)
+    str_cols = df.select_dtypes(include="string").columns
+    df = df.astype({c: object for c in str_cols})
+    return df
+
+
+st.markdown("""
+## Dask mentions on GitHub
+### Commits
+""")
+df = get_data("commits")
+st.dataframe(
+    df,
+    column_config={
+        "repo": st.column_config.LinkColumn("repo"),
+        "username": st.column_config.LinkColumn("user"),
+    },
+    hide_index=True,
+)
+st.markdown("""
+### Comments
+""")
+df = get_data("comments")
+st.dataframe(
+    df,
+    column_config={
+        "repo": st.column_config.LinkColumn("repo"),
+        "username": st.column_config.LinkColumn("user"),
+    },
+    hide_index=True,
+)


### PR DESCRIPTION
This PR adds a very basic streamlit app that displays the `dask`-related mentions from https://github.com/coiled/etl-github/pull/4. 

![Screenshot 2024-03-01 at 3 28 19 PM](https://github.com/coiled/etl-github/assets/11656932/2b37a315-95f0-44a3-baad-15e3d00c668d)

You can run the dashboard with `$ streamlit run dashboard.py`

Mostly just pushing this up so we have something and can update this as we update how we're formatting / querying our processed GitHub data